### PR TITLE
RDKB-63135, RDKB-63664 : Handle Security Edge feature for business - Add T2 markers

### DIFF
--- a/source/dmlxdns/cosa_xdns_apis.c
+++ b/source/dmlxdns/cosa_xdns_apis.c
@@ -80,7 +80,6 @@ extern ANSC_HANDLE bus_handle;
 #include "ccsp_xdnsLog_wrapper.h"
 #include "safec_lib_common.h"
 #include "secure_wrapper.h"
-#include <telemetry_busmessage_sender.h>
 //static pthread_mutex_t dnsmasqMutex = PTHREAD_MUTEX_INITIALIZER;
 
 #define BUF_LEN (10 * (sizeof(struct inotify_event) + NAME_MAX + 1))

--- a/source/dmlxdns/cosa_xdns_apis.h
+++ b/source/dmlxdns/cosa_xdns_apis.h
@@ -19,6 +19,7 @@
 
 #include "cosa_apis.h"
 #include "dslh_definitions_tr143.h"
+#include <telemetry_busmessage_sender.h>
 
 #define RESOLV_CONF "/etc/resolv.conf"
 #define DNSMASQ_SERVERS_CONF "/nvram/dnsmasq_servers.conf"

--- a/source/dmlxdns/cosa_xdns_dml.c
+++ b/source/dmlxdns/cosa_xdns_dml.c
@@ -718,6 +718,7 @@ XDNS_SetParamBoolValue
         if (!is_devicemode_business())
         {
             CcspTraceInfo(("[XDNS] DNSSec feature not supported in residential mode\n"));
+            t2_event_d("XDNS_DNSSec_NotSupported", 1);
             return FALSE;
         }
 #endif // _ONESTACK_PRODUCT_REQ_


### PR DESCRIPTION
Reason for change: Handle Security Edge feature for business - Add T2 markers
Test Procedure:

- residential and business devicemode needs to be tested.

Functionality of the following DMLs need to be tested:
```
Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.EnableMultiProfileXDNS
Device.X_RDKCENTRAL-COM_XDNS.DNSSecEnable
```
Above mentioned DML parameters SHOULD work only if the devicemode is business.

Risks: Low
Priority: P1

Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com