### PR TITLE
RDKB-65075: Fix native build failure

### DIFF
--- a/cov_docker_script/configure_options.conf
+++ b/cov_docker_script/configure_options.conf
@@ -9,6 +9,9 @@
 # Autotools configuration
 -DHAVE_CONFIG_H
 
+# Safec dummy API
+-DSAFEC_DUMMY_API
+
 # Include paths
 -I$HOME/usr/include/rdkb/
 -I/usr/include/dbus-1.0


### PR DESCRIPTION
Reason for change: Native build for Coverity scan
Test Procedure: Native build should be success
Priority: P1
Risks: None
Signed-off-by: Netaji Panigrahi [Netaji_Panigrahi@comcast.com](mailto:Netaji_Panigrahi@comcast.com)